### PR TITLE
fix: replace broken claude-code flake input with sadjow overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,24 @@
 {
   "nodes": {
-    "claude-code": {
+    "claude-code-nix": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1741039721,
-        "narHash": "sha256-BPIOQB/BlPHOfO0uKZMk/FTrWo7gcX92TPGSjtP82uI=",
-        "ref": "refs/heads/main",
-        "rev": "a07a09abdd2aaff003716990a014ea972b2e8bfb",
-        "revCount": 2,
-        "type": "git",
-        "url": "https://codeberg.org/MachsteNix/claude-code-nix"
+        "lastModified": 1775271377,
+        "narHash": "sha256-0ru4G0uQeokPTlJGuRHf3ApBZMeuIRdUyp0SYi//RWM=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "214fdf6592f40a8bb472e80283c029d01fb6653d",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://codeberg.org/MachsteNix/claude-code-nix"
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
       }
     },
     "flake-compat": {
@@ -60,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774647770,
-        "narHash": "sha256-UNNi14XiqRWWjO8ykbFwA5wRwx7EscsC+GItOVpuGjc=",
+        "lastModified": 1775320414,
+        "narHash": "sha256-pIDPHus8udcxO4lT+zUULBfvue2D08E73abzVEJNE+8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "02371c05a04a2876cf92e2d67a259e8f87399068",
+        "rev": "5ee3b3ef63e469c84639c2c9e282726352c86069",
         "type": "github"
       },
       "original": {
@@ -80,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "lastModified": 1775037210,
+        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
         "type": "github"
       },
       "original": {
@@ -101,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773882647,
-        "narHash": "sha256-VzcOcE0LLpEnyoxLuMuptZ9ZWCkSBn99bTgEQoz5Viw=",
+        "lastModified": 1774972752,
+        "narHash": "sha256-DnLIpFxznohpLkIFs390uZ0gxwkVyhtknhKNu+lQJK8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "fd0eae98d1ecee31024271f8d64676250a386ee7",
+        "rev": "d97e078f4788cddb8d11c3c99f72a4bb9ddec221",
         "type": "github"
       },
       "original": {
@@ -116,27 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -148,11 +134,11 @@
     },
     "root": {
       "inputs": {
-        "claude-code": "claude-code",
+        "claude-code-nix": "claude-code-nix",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     # Nixpkgs - use unstable for latest packages
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    claude-code.url = "git+https://codeberg.org/MachsteNix/claude-code-nix";
+    claude-code-nix = {
+      url = "github:sadjow/claude-code-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     # Home Manager - for user-level configuration
     home-manager = {
@@ -35,6 +38,8 @@
       ...
     }@inputs:
     let
+      claudeOverlay = inputs.claude-code-nix.overlays.default;
+
       # Helper function to generate system configurations
       mkSystem =
         {
@@ -44,7 +49,9 @@
         }:
         nixpkgs.lib.nixosSystem {
           inherit system;
-          modules = modules;
+          modules = modules ++ [
+            { nixpkgs.overlays = [ claudeOverlay ]; }
+          ];
           specialArgs = specialArgs // {
             inherit inputs;
           };
@@ -61,6 +68,7 @@
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
+            overlays = [ claudeOverlay ];
           };
           modules = modules;
           extraSpecialArgs = { inherit inputs; };

--- a/home/modules/dev-tools.nix
+++ b/home/modules/dev-tools.nix
@@ -26,6 +26,6 @@
     nix-tree
 
     # AI
-    pkgs.claude-code
+    claude-code
   ];
 }


### PR DESCRIPTION
## Summary

- When updating the flake to pick up Neovim 0.12, the existing `claude-code` input (pointing to `codeberg.org/MachsteNix/claude-code-nix`) became invalid — nixpkgs-unstable's `claude-code` 2.1.88 had broken source URLs returning 404 on both npm and the Google Storage binary mirror
- Replaced the dead `MachsteNix` Codeberg input with the `sadjow/claude-code-nix` overlay (`github:sadjow/claude-code-nix`), which is automatically updated hourly and provides a working native binary (currently 2.1.92)
- The overlay is wired via `nixpkgs.overlays` in `mkSystem` (NixOS) and `overlays` in `mkHome` (standalone Home Manager), overriding the broken nixpkgs package for all configurations
- `inputs.nixpkgs.follows = "nixpkgs"` is set so the overlay shares the same nixpkgs as the rest of the flake

## Test plan

- [x] `nix flake update` completes without errors
- [x] `make switch` builds successfully with `claude-code-2.1.92`
- [x] `claude --version` works after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)