### PR TITLE
Fix first-run WSL Home Manager activation

### DIFF
--- a/docs/README.nix.md
+++ b/docs/README.nix.md
@@ -24,9 +24,11 @@ nix --extra-experimental-features 'nix-command flakes' run github:user3301/dotfi
 the distribution's virtual disk; `nixos-anywhere` is intended to provision an
 SSH target and normally repartition its disks.
 
-This creates the `user3301` configuration, clones the repository to
-`/home/user3301/dotfiles`, and activates the local checkout. Then run
-`wsl --shutdown` from PowerShell and reopen the distribution.
+This first creates `user3301` without activating Home Manager, clones the
+repository to `/home/user3301/dotfiles`, and then activates the full
+configuration from that checkout. It is safe to rerun after an interrupted
+bootstrap. When it completes, run `wsl --shutdown` from PowerShell and reopen
+the distribution.
 
 ### NixOS Native
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -137,20 +137,25 @@
           specialArgs = { inherit inputs; };
         };
 
+      wslSystemModules = [
+        nixos-wsl.nixosModules.wsl
+        ./systems/wsl/configuration.nix
+      ];
+
     in
     {
       # NixOS Configurations
       nixosConfigurations = {
+        # Minimal first-stage configuration used by the WSL bootstrap app.
+        nixos-wsl-bootstrap = mkSystem {
+          system = "x86_64-linux";
+          modules = wslSystemModules;
+        };
+
         # NixOS WSL2 Configuration
         nixos-wsl = mkSystem {
           system = "x86_64-linux";
-          modules = [
-            # WSL-specific module
-            nixos-wsl.nixosModules.wsl
-
-            # System configuration
-            ./systems/wsl/configuration.nix
-
+          modules = wslSystemModules ++ [
             # Home Manager integration
             home-manager.nixosModules.home-manager
             {

--- a/home/nixos-wsl.nix
+++ b/home/nixos-wsl.nix
@@ -12,6 +12,10 @@
     ./modules/languages.nix
   ];
 
+  # During bootstrap there may be no active user session yet. Let the normal
+  # WSL login start sockets and services instead of starting them during switch.
+  systemd.user.startServices = "suggest";
+
   home = {
     # User information
     username = "user3301";

--- a/scripts/bootstrap-nixos-wsl.sh
+++ b/scripts/bootstrap-nixos-wsl.sh
@@ -32,7 +32,7 @@ fi
 export NIX_CONFIG="${NIX_CONFIG:-}"$'\nexperimental-features = nix-command flakes'
 
 echo "Creating the ${target_user} NixOS configuration..."
-sudo nixos-rebuild switch --flake "${flake_ref}#nixos-wsl"
+sudo nixos-rebuild switch --flake "${flake_ref}#nixos-wsl-bootstrap"
 
 if [[ -d "${target_repo}/.git" ]]; then
   echo "Updating the existing checkout at ${target_repo}..."


### PR DESCRIPTION
Fix the bootstrap error introduced by https://github.com/user3301/dotfiles/pull/17

```sh
warning: the following units failed: home-manager-user3301.service
× home-manager-user3301.service - Home Manager environment for user3301
     Loaded: loaded (/etc/systemd/system/home-manager-user3301.service; enabled; preset: ignored)
     Active: failed (Result: exit-code) since Sat 2026-08-15 17:00:12 AEST; 486ms ago
 Invocation: 73c463b401d643438156d2a39fc2ca0c
    Process: 20965 ExecStart=/nix/store/4yzqkkz0ncgjrd936xavhk7jcbwk4asw-hm-setup-env /nix/store/xdgv68mhdl4jdv5233189vx8f0wxdqi1-home-manager-generation (code=exited, status=1/FAILURE)
   Main PID: 20965 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 4K read, 0B written
   Mem peak: 35.7M
        CPU: 492ms

Aug 15 17:00:12 nixos hm-activate-user3301[20965]: Activating linkGeneration
Aug 15 17:00:12 nixos hm-activate-user3301[20965]: Creating home file links in /home/user3301
Aug 15 17:00:12 nixos hm-activate-user3301[20965]: Activating onFilesChange
Aug 15 17:00:12 nixos hm-activate-user3301[20965]: Activating reloadSystemd
Aug 15 17:00:12 nixos hm-activate-user3301[21228]: Starting units: gpg-agent.socket
Aug 15 17:00:12 nixos hm-activate-user3301[21228]: Error: Error switching systemd units
Aug 15 17:00:12 nixos hm-activate-user3301[21228]: Caused by:
Aug 15 17:00:12 nixos hm-activate-user3301[21228]:     0: Failed to perform post-reload tasks
Aug 15 17:00:12 nixos hm-activate-user3301[21228]:     1: Failed to start unit gpg-agent.socket
Aug 15 17:00:12 nixos hm-activate-user3301[21228]:     2: org.freedesktop.systemd1.NoSuchUnit: Unit gpg-agent.socket not found.
Command 'systemd-run -E LOCALE_ARCHIVE -E NIXOS_INSTALL_BOOTLOADER -E NIXOS_NO_CHECK --collect --no-ask-password --pipe --quiet --service-type=exec --unit=nixos-rebuild-switch-to-configuration /nix/store/p7k7y2xkxm9gbxdm4pp7k036k9mf9jl6-nixos-system-nixos-26.05.20260809.fcb8fcd/bin/switch-to-configuration switch' returned non-zero exit status 4.
```