### PR TITLE
Clone WSL dotfiles during activation

### DIFF
--- a/docs/README.nix.md
+++ b/docs/README.nix.md
@@ -24,11 +24,12 @@ nix --extra-experimental-features 'nix-command flakes' run github:user3301/dotfi
 the distribution's virtual disk; `nixos-anywhere` is intended to provision an
 SSH target and normally repartition its disks.
 
-This first creates `user3301` without activating Home Manager, clones the
-repository to `/home/user3301/dotfiles`, and then activates the full
-configuration from that checkout. It is safe to rerun after an interrupted
-bootstrap. When it completes, run `wsl --shutdown` from PowerShell and reopen
-the distribution.
+The bootstrap configuration clones the repository to
+`/home/user3301/dotfiles` as part of NixOS activation, before Home Manager
+starts. This remains reliable even when changing WSL's default user terminates
+the original shell session. It is safe to rerun after an interrupted bootstrap.
+When it completes, run `wsl --shutdown` from PowerShell and reopen the
+distribution.
 
 ### NixOS Native
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -162,29 +162,32 @@
         # Home Manager activates the same configuration as nixos-wsl.
         nixos-wsl-bootstrap = mkSystem {
           system = "x86_64-linux";
-          modules = wslSystemModules ++ wslHomeManagerModules ++ [
-            (
-              { pkgs, ... }:
-              {
-                system.activationScripts.bootstrapDotfiles = {
-                  deps = [ "users" ];
-                  text = ''
-                    target=/home/user3301/dotfiles
-                    if [[ ! -e "$target" ]]; then
-                      echo "cloning dotfiles into $target..."
-                      ${pkgs.coreutils}/bin/install -d -o user3301 -g users /home/user3301
-                      ${pkgs.util-linux}/bin/runuser -u user3301 -- \
-                        ${pkgs.git}/bin/git clone \
-                          https://github.com/user3301/dotfiles.git "$target"
-                    elif [[ ! -d "$target/.git" ]]; then
-                      echo "error: $target exists but is not a Git checkout" >&2
-                      exit 1
-                    fi
-                  '';
-                };
-              }
-            )
-          ];
+          modules =
+            wslSystemModules
+            ++ wslHomeManagerModules
+            ++ [
+              (
+                { pkgs, ... }:
+                {
+                  system.activationScripts.bootstrapDotfiles = {
+                    deps = [ "users" ];
+                    text = ''
+                      target=/home/user3301/dotfiles
+                      if [[ ! -e "$target" ]]; then
+                        echo "cloning dotfiles into $target..."
+                        ${pkgs.coreutils}/bin/install -d -o user3301 -g users /home/user3301
+                        ${pkgs.util-linux}/bin/runuser -u user3301 -- \
+                          ${pkgs.git}/bin/git clone \
+                            https://github.com/user3301/dotfiles.git "$target"
+                      elif [[ ! -d "$target/.git" ]]; then
+                        echo "error: $target exists but is not a Git checkout" >&2
+                        exit 1
+                      fi
+                    '';
+                  };
+                }
+              )
+            ];
         };
 
         # NixOS WSL2 Configuration

--- a/flake.nix
+++ b/flake.nix
@@ -142,31 +142,55 @@
         ./systems/wsl/configuration.nix
       ];
 
+      wslHomeManagerModules = [
+        home-manager.nixosModules.home-manager
+        {
+          home-manager = {
+            useGlobalPkgs = true;
+            useUserPackages = true;
+            users.user3301 = import ./home/nixos-wsl.nix;
+            extraSpecialArgs = { inherit inputs; };
+          };
+        }
+      ];
+
     in
     {
       # NixOS Configurations
       nixosConfigurations = {
-        # Minimal first-stage configuration used by the WSL bootstrap app.
+        # One-time installer that clones the mutable dotfiles checkout before
+        # Home Manager activates the same configuration as nixos-wsl.
         nixos-wsl-bootstrap = mkSystem {
           system = "x86_64-linux";
-          modules = wslSystemModules;
+          modules = wslSystemModules ++ wslHomeManagerModules ++ [
+            (
+              { pkgs, ... }:
+              {
+                system.activationScripts.bootstrapDotfiles = {
+                  deps = [ "users" ];
+                  text = ''
+                    target=/home/user3301/dotfiles
+                    if [[ ! -e "$target" ]]; then
+                      echo "cloning dotfiles into $target..."
+                      ${pkgs.coreutils}/bin/install -d -o user3301 -g users /home/user3301
+                      ${pkgs.util-linux}/bin/runuser -u user3301 -- \
+                        ${pkgs.git}/bin/git clone \
+                          https://github.com/user3301/dotfiles.git "$target"
+                    elif [[ ! -d "$target/.git" ]]; then
+                      echo "error: $target exists but is not a Git checkout" >&2
+                      exit 1
+                    fi
+                  '';
+                };
+              }
+            )
+          ];
         };
 
         # NixOS WSL2 Configuration
         nixos-wsl = mkSystem {
           system = "x86_64-linux";
-          modules = wslSystemModules ++ [
-            # Home Manager integration
-            home-manager.nixosModules.home-manager
-            {
-              home-manager = {
-                useGlobalPkgs = true;
-                useUserPackages = true;
-                users.user3301 = import ./home/nixos-wsl.nix;
-                extraSpecialArgs = { inherit inputs; };
-              };
-            }
-          ];
+          modules = wslSystemModules ++ wslHomeManagerModules;
         };
 
         # Native NixOS Configuration
@@ -216,8 +240,6 @@
         pkgs.writeShellApplication {
           name = "bootstrap-nixos-wsl";
           runtimeInputs = with pkgs; [
-            coreutils
-            git
             gnugrep
           ];
           text = builtins.readFile ./scripts/bootstrap-nixos-wsl.sh;

--- a/scripts/bootstrap-nixos-wsl.sh
+++ b/scripts/bootstrap-nixos-wsl.sh
@@ -1,19 +1,14 @@
 set -euo pipefail
 
 flake_ref="${DOTFILES_FLAKE:-github:user3301/dotfiles}"
-repo_url="${DOTFILES_REPO_URL:-https://github.com/user3301/dotfiles.git}"
 target_user="user3301"
-target_home="/home/${target_user}"
-target_repo="${target_home}/dotfiles"
-git_bin="$(command -v git)"
 
 if [[ "${1:-}" == "--help" ]]; then
   cat <<EOF
 Bootstrap this dotfiles configuration on an existing NixOS-WSL installation.
 
 Environment overrides:
-  DOTFILES_FLAKE     Flake reference used for the initial switch
-  DOTFILES_REPO_URL  Git URL cloned into ${target_repo}
+  DOTFILES_FLAKE  Flake reference used for the installation
 EOF
   exit 0
 fi
@@ -33,20 +28,6 @@ export NIX_CONFIG="${NIX_CONFIG:-}"$'\nexperimental-features = nix-command flake
 
 echo "Creating the ${target_user} NixOS configuration..."
 sudo nixos-rebuild switch --flake "${flake_ref}#nixos-wsl-bootstrap"
-
-if [[ -d "${target_repo}/.git" ]]; then
-  echo "Updating the existing checkout at ${target_repo}..."
-  sudo -H -u "${target_user}" "${git_bin}" -C "${target_repo}" pull --ff-only
-elif [[ -e "${target_repo}" ]]; then
-  echo "error: ${target_repo} exists but is not a Git checkout" >&2
-  exit 1
-else
-  echo "Cloning dotfiles into ${target_repo}..."
-  sudo -H -u "${target_user}" "${git_bin}" clone "${repo_url}" "${target_repo}"
-fi
-
-echo "Activating the configuration from the local checkout..."
-sudo nixos-rebuild switch --flake "${target_repo}#nixos-wsl"
 
 cat <<EOF
 


### PR DESCRIPTION
This PR fixes the issue that during bootstrapping, the repo is not cloned into created user after WSL changing the default user.