### PR TITLE
Add kubectl and kubectx to dev-tools

### DIFF
--- a/home/modules/dev-tools.nix
+++ b/home/modules/dev-tools.nix
@@ -21,6 +21,10 @@
     gnumake
     xdg-utils
 
+    # Kubernetes
+    kubectl
+    kubectx
+
     # Nix development
     nil # Nix LSP
     nixpkgs-fmt


### PR DESCRIPTION
## Summary

Adds a `# Kubernetes` section to the shared `home/modules/dev-tools.nix` module with `kubectl` and `kubectx`.

Since `dev-tools.nix` is imported by all four profiles (`darwin`, `archlinux`, `nixos-native`, `nixos-wsl`), these land on every host.

## Notes

- `kubectx` ships both `kubectx` and `kubens` binaries in a single derivation — verified by building `kubectx-0.11.0` from the pinned nixpkgs and listing its `bin/`, so no separate `kubens` entry is needed.
- `nix-instantiate --parse` passes on the modified file.
- Not yet applied to any host; requires a Home Manager switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)